### PR TITLE
Use simplejson instead for better parsing errors

### DIFF
--- a/json_to_csv.py
+++ b/json_to_csv.py
@@ -1,5 +1,5 @@
 import sys
-import json
+import simplejson
 import csv
 
 ##
@@ -69,7 +69,7 @@ if __name__ == "__main__":
 
         fp = open(json_file_path, 'r')
         json_value = fp.read()
-        raw_data = json.loads(json_value)
+        raw_data = simplejson.loads(json_value)
 
         try:
             data_to_be_processed = raw_data[node]


### PR DESCRIPTION
I was using this and ran into a vague JSON parsing error. This [SO post](https://stackoverflow.com/a/14956465/34315) put onto [simplejson](https://github.com/vinay20045/json-to-csv) and it helped me resolve the error.